### PR TITLE
Fix crypto deprecation warnings and update README

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ typedoc.js
 webpack.config.js
 test/
 dist/browser*
+dist/*.map

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The official Javascript SDK for interacting with [RenEx](https://ren.exchange) -
 ## Links
 
 * [Official SDK Docs](https://republicprotocol.github.io/renex-sdk-docs)
+* [Cloneable Examples](https://github.com/republicprotocol/renex-sdk-examples-js)
 
 ## Installation
 
@@ -36,14 +37,15 @@ import { RenExSDK } from "@renex/renex";
 
 ## Usage
 
-Pass in a provider object to instantiate the SDK.
+Pass in a provider object to instantiate the SDK and set the address.
 
 ```javascript
 var provider = window.web3.currentProvider;
 var sdk = new RenExSDK(provider);
+sdk.setAddress(window.web3.eth.defaultAccount);
 ```
 
-For information on SDK usage, check out the [official SDK Docs](https://republicprotocol.github.io/renex-sdk-docs).
+For information on SDK usage, check out the [official SDK Docs](https://republicprotocol.github.io/renex-sdk-docs) or clone the [examples repository](https://github.com/republicprotocol/renex-sdk-examples-js).
 
 ## For Developers
 

--- a/README.md
+++ b/README.md
@@ -8,18 +8,42 @@ The official Javascript SDK for interacting with [RenEx](https://ren.exchange) -
 
 ## Installation
 
+Add the RenExSDK using NPM
+
 ```bash
 npm install --save @renex/renex
 ```
 
-## Usage
+Add the RenExSDK using Yarn
+
+```bash
+yarn add @renex/renex
+```
+
+## Importing the SDK
+
+Importing using the require syntax
 
 ```javascript
 var { RenExSDK } = require("@renex/renex");
+```
 
+Importing using the ES6 syntax
+
+```javascript
+import { RenExSDK } from "@renex/renex";
+```
+
+## Usage
+
+Pass in a provider object to instantiate the SDK.
+
+```javascript
 var provider = window.web3.currentProvider;
 var sdk = new RenExSDK(provider);
 ```
+
+For information on SDK usage, check out the [official SDK Docs](https://republicprotocol.github.io/renex-sdk-docs).
 
 ## For Developers
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ Pass in a provider object to instantiate the SDK and set the address.
 ```javascript
 var provider = window.web3.currentProvider;
 var sdk = new RenExSDK(provider);
-sdk.setAddress(window.web3.eth.defaultAccount);
+```
+
+Before you can use account specific functions such as fetching account balances or opening orders, you must tell the SDK which Ethereum account to use. This address must be the same one that has been KYC'd via Kyber or Wyre. You can check if your account has been verified by visiting [RenEx Beta](https://ren.exchange).
+
+```javascript
+sdk.setAddress("0xece04c40dc55b1c6e3882966ed41e7982f3d26a6");
 ```
 
 For information on SDK usage, check out the [official SDK Docs](https://republicprotocol.github.io/renex-sdk-docs) or clone the [examples repository](https://github.com/republicprotocol/renex-sdk-examples-js).

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import LocalStorage from "./storage/localStorage";
 import { DarknodeRegistry, Orderbook, RenExBalances, RenExSettlement, RenExTokens, withProvider, Wyre } from "./contracts/contracts";
 import { generateConfig } from "./lib/config";
 import { normalizePrice, normalizeVolume, toOriginalType } from "./lib/conversion";
+import { EncodedData, Encodings } from "./lib/encodedData";
 import { fetchMarkets } from "./lib/market";
 import { NetworkData, networks } from "./lib/network";
 import { supportedTokens } from "./lib/tokens";
@@ -189,7 +190,8 @@ export class RenExSDK {
     public getAddress = (): string => this._address;
     public getConfig = (): Config => this._config;
 
-    public setAddress = (address: string): void => {
+    public setAddress = (addr: string): void => {
+        const address = new EncodedData(addr, Encodings.HEX).toHex();
         this._address = address;
         if (this.getConfig().storageProvider === "localStorage") {
             this._storage = new LocalStorage(address);

--- a/src/lib/shamir.ts
+++ b/src/lib/shamir.ts
@@ -1,5 +1,5 @@
 import { BN } from "bn.js";
-import * as crypto from "crypto";
+import crypto from "crypto";
 import { List } from "immutable";
 
 export const PRIME: BN = new BN("17012364981921935471");

--- a/test/index.html
+++ b/test/index.html
@@ -5,7 +5,6 @@
     <script>
         const sdk = new RenExSDK(window.web3.currentProvider, { network: "testnet" });
         sdk.setAddress(window.web3.eth.defaultAccount);
-        sdk.withdraw(1, 1);
     </script>
     <p>Open console</p>
 </body>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
+        "baseUrl": "src",
+        "rootDir": "src",
         "lib": [
             "es2015",
             "es2017"
@@ -23,7 +25,7 @@
         "strictPropertyInitialization": true
     },
     "include": [
-        "src/**/*.ts",
+        "src/**/*",
         "src/global.d.ts",
         "node_modules/@types"
     ],


### PR DESCRIPTION
This PR fixes the following DeprecationWarnings.

```
(node:33401) [DEP0010] DeprecationWarning: crypto.createCredentials is deprecated. Use tls.createSecureContext instead.
(node:33401) [DEP0011] DeprecationWarning: crypto.Credentials is deprecated. Use tls.SecureContext instead.
```

It also updates the README with more useful setup information and also points to the [cloneable examples repo](https://github.com/republicprotocol/renex-sdk-examples-js/).