### PR TITLE
Allow setting of the address to empty string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ export class RenExSDK {
     public getConfig = (): Config => this._config;
 
     public setAddress = (addr: string): void => {
-        const address = new EncodedData(addr, Encodings.HEX).toHex();
+        const address = addr === "" ? "" : new EncodedData(addr, Encodings.HEX).toHex();
         this._address = address;
         if (this.getConfig().storageProvider === "localStorage") {
             this._storage = new LocalStorage(address);


### PR DESCRIPTION
Previously, after allowing the omission of 0x in the address we didn't consider that we may want to set the address to "". This caused problems because it believes that the 0x0 address is valid.

This PR fixes this issue.