### PR TITLE
Warn when expected network ID differs from provider network ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The official Javascript SDK for interacting with [RenEx](https://ren.exchange) -
 ## Links
 
 * [Official SDK Docs](https://republicprotocol.github.io/renex-sdk-docs)
-* [Cloneable Examples](https://github.com/republicprotocol/renex-sdk-examples-js)
+* [Cloneable Examples](https://github.com/republicprotocol/renex-sdk-examples)
 
 ## Installation
 
@@ -50,7 +50,7 @@ Before you can use account specific functions such as fetching account balances 
 sdk.setAddress("0xece04c40dc55b1c6e3882966ed41e7982f3d26a6");
 ```
 
-For information on SDK usage, check out the [official SDK Docs](https://republicprotocol.github.io/renex-sdk-docs) or clone the [examples repository](https://github.com/republicprotocol/renex-sdk-examples-js).
+For information on SDK usage, check out the [official SDK Docs](https://republicprotocol.github.io/renex-sdk-docs) or clone the [examples repository](https://github.com/republicprotocol/renex-sdk-examples).
 
 ## For Developers
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,13 @@ export class RenExSDK {
                 throw new Error(`Unsupported network field: ${this.getConfig().network}`);
         }
 
+        // Show warning when the expected network ID is different from the provider network ID
+        this._web3.eth.net.getId().then(networkId => {
+            if (networkId !== this._networkData.ethNetworkId) {
+                console.warn(`Your provider is not using the ${this._networkData.ethNetworkLabel} Ethereum network!`);
+            }
+        });
+
         this._cachedTokenDetails = this._cachedTokenDetails
             .set(Token.BTC, Promise.resolve({ addr: "0x0000000000000000000000000000000000000000", decimals: new BN(8), registered: true }))
             .set(Token.ETH, Promise.resolve({ addr: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", decimals: new BN(18), registered: true }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { WyreContract } from "./contracts/bindings/wyre";
 // Export all types
 export * from "./types";
 export { StorageProvider } from "./storage/interface";
+export { deserializeBalanceAction, deserializeTraderOrder, serializeBalanceAction, serializeTraderOrder } from "./storage/serializers";
 
 /**
  * This is the concrete class that implements the IRenExSDK interface.

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { fetchBalanceActions, fetchTraderOrders } from "./methods/storageMethods
 import { FileSystemStorage } from "./storage/fileSystemStorage";
 import { StorageProvider } from "./storage/interface";
 import { MemoryStorage } from "./storage/memoryStorage";
-import { AtomicBalanceDetails, AtomicConnectionStatus, BalanceAction, BalanceDetails, Config, MarketDetails, MatchDetails, NumberInput, Options, Order, OrderbookFilter, OrderID, OrderInputs, OrderSide, OrderStatus, SimpleConsole, Token, TokenCode, TokenDetails, TraderOrder, Transaction, TransactionStatus } from "./types";
+import { AtomicBalanceDetails, AtomicConnectionStatus, BalanceAction, BalanceDetails, Config, MarketDetails, MatchDetails, NumberInput, Options, Order, OrderbookFilter, OrderID, OrderInputs, OrderSide, OrderStatus, SimpleConsole, Token, TokenCode, TokenDetails, TraderOrder, Transaction, TransactionStatus, TransactionOptions, WithdrawTransactionOptions } from "./types";
 
 // Contract bindings
 import { DarknodeRegistryContract } from "./contracts/bindings/darknode_registry";
@@ -164,18 +164,18 @@ export class RenExSDK {
     public fetchSupportedAtomicTokens = (): Promise<TokenCode[]> => supportedAtomicTokens(this);
 
     // Transaction Methods
-    public deposit = (value: NumberInput, token: TokenCode):
+    public deposit = (value: NumberInput, token: TokenCode, options?: TransactionOptions):
         Promise<{ balanceAction: BalanceAction, promiEvent: PromiEvent<Transaction> | null }> =>
-        deposit(this, value, token)
-    public withdraw = (value: NumberInput, token: TokenCode, withoutIngressSignature = false):
+        deposit(this, value, token, options)
+    public withdraw = (value: NumberInput, token: TokenCode, options?: WithdrawTransactionOptions):
         Promise<{ balanceAction: BalanceAction, promiEvent: PromiEvent<Transaction> | null }> =>
-        withdraw(this, value, token, withoutIngressSignature)
-    public openOrder = (order: OrderInputs, simpleConsole?: SimpleConsole):
+        withdraw(this, value, token, options)
+    public openOrder = (order: OrderInputs, options?: TransactionOptions):
         Promise<{ traderOrder: TraderOrder, promiEvent: PromiEvent<Transaction> | null }> =>
-        openOrder(this, order, simpleConsole)
-    public cancelOrder = (orderID: OrderID):
+        openOrder(this, order, options)
+    public cancelOrder = (orderID: OrderID, options?: TransactionOptions):
         Promise<{ promiEvent: PromiEvent<Transaction> | null }> =>
-        cancelOrder(this, orderID)
+        cancelOrder(this, orderID, options)
 
     public fetchDarknodeFeePercent = (): Promise<BigNumber> => darknodeFees(this);
     public fetchMinEthTradeVolume = (): Promise<BigNumber> => getMinEthTradeVolume(this);

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { fetchBalanceActions, fetchTraderOrders } from "./methods/storageMethods
 import { FileSystemStorage } from "./storage/fileSystemStorage";
 import { StorageProvider } from "./storage/interface";
 import { MemoryStorage } from "./storage/memoryStorage";
-import { AtomicBalanceDetails, AtomicConnectionStatus, BalanceAction, BalanceDetails, Config, MarketDetails, MatchDetails, NumberInput, Options, Order, OrderbookFilter, OrderID, OrderInputs, OrderSide, OrderStatus, SimpleConsole, Token, TokenCode, TokenDetails, TraderOrder, Transaction, TransactionStatus, TransactionOptions, WithdrawTransactionOptions } from "./types";
+import { AtomicBalanceDetails, AtomicConnectionStatus, BalanceAction, BalanceDetails, Config, MarketDetails, MatchDetails, NumberInput, Options, Order, OrderbookFilter, OrderID, OrderInputs, OrderSide, OrderStatus, SimpleConsole, Token, TokenCode, TokenDetails, TraderOrder, Transaction, TransactionOptions, TransactionStatus, WithdrawTransactionOptions } from "./types";
 
 // Contract bindings
 import { DarknodeRegistryContract } from "./contracts/bindings/darknode_registry";

--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -8,7 +8,7 @@ export interface NetworkData {
     etherscan: string;
     ethNetwork: string;
     ethNetworkLabel: string;
-    ledgerNetworkId: number;
+    ethNetworkId: number;
     contracts: [
         {
             darknodeRegistry: string;

--- a/src/lib/networks/mainnet.json
+++ b/src/lib/networks/mainnet.json
@@ -5,7 +5,7 @@
     "etherscan": "https://etherscan.io",
     "ethNetwork": "main",
     "ethNetworkLabel": "Main",
-    "ledgerNetworkId": 42,
+    "ethNetworkId": 1,
     "contracts": [
         {
             "darknodeRegistry": "0x3799006a87FDE3CCFC7666B3E6553B03ED341c2F",

--- a/src/lib/networks/testnet.json
+++ b/src/lib/networks/testnet.json
@@ -5,7 +5,7 @@
     "etherscan": "https://kovan.etherscan.io",
     "ethNetwork": "kovan",
     "ethNetworkLabel": "Kovan",
-    "ledgerNetworkId": 42,
+    "ethNetworkId": 42,
     "contracts": [
         {
             "darknodeRegistry": "0x75Fa8349fc9C7C640A4e9F1A1496fBB95D2Dc3d5",

--- a/src/methods/balanceActionMethods.ts
+++ b/src/methods/balanceActionMethods.ts
@@ -4,7 +4,7 @@ import BN from "bn.js";
 import PromiEvent from "web3/promiEvent";
 
 import RenExSDK from "../index";
-import { BalanceAction, BalanceActionType, NumberInput, Token, TokenCode, TokenDetails, Transaction, TransactionOptions, TransactionStatus } from "../types";
+import { BalanceAction, BalanceActionType, NumberInput, Token, TokenCode, TokenDetails, Transaction, TransactionOptions, TransactionStatus, WithdrawTransactionOptions } from "../types";
 
 import { ERC20Contract } from "../contracts/bindings/erc20";
 import { ERC20, withProvider } from "../contracts/contracts";
@@ -178,13 +178,12 @@ export const withdraw = async (
     sdk: RenExSDK,
     value: NumberInput,
     token: TokenCode,
-    withoutIngressSignature: boolean,
-    options?: TransactionOptions,
+    options?: WithdrawTransactionOptions,
 ): Promise<{ balanceAction: BalanceAction, promiEvent: PromiEvent<Transaction> | null }> => {
     value = new BigNumber(value);
 
     // Trustless withdrawals are not implemented yet
-    if (withoutIngressSignature === true) {
+    if (options && options.withoutIngressSignature === true) {
         throw new Error(ErrUnimplemented);
     }
 

--- a/src/methods/balanceActionMethods.ts
+++ b/src/methods/balanceActionMethods.ts
@@ -12,7 +12,7 @@ import { ErrCanceledByUser, ErrFailedBalanceCheck, ErrInsufficientBalance, ErrIn
 import { requestWithdrawalSignature } from "../lib/ingress";
 import { toSmallestUnit } from "../lib/tokens";
 import { balances, getTokenDetails } from "./balancesMethods";
-import { getGasPrice, getTransactionStatus } from "./generalMethods";
+import { getTransactionStatus } from "./generalMethods";
 import { defaultTransactionOptions } from "./orderbookMethods";
 import { fetchBalanceActions } from "./storageMethods";
 

--- a/src/methods/orderbookMethods.ts
+++ b/src/methods/orderbookMethods.ts
@@ -299,11 +299,14 @@ export const getOrders = async (
         orders = orders.filter((order: [string, OrderStatus, string]) => order[2].toLowerCase() === filterAddress.toLowerCase()).toList();
     }
 
-    return orders.map((order: [string, OrderStatus, string]) => ({
-        id: order[0],
-        status: order[1],
-        trader: order[2],
-    })).toArray();
+    return orders.map((order: [string, OrderStatus, string]) => {
+        const orderID = new EncodedData(order[0], Encodings.HEX).toBase64();
+        return {
+            id: orderID,
+            status: order[1],
+            trader: order[2],
+        };
+    }).toArray();
 };
 
 export const updateAllOrderStatuses = async (sdk: RenExSDK, orders?: TraderOrder[]): Promise<Map<string, OrderStatus>> => {

--- a/src/methods/orderbookMethods.ts
+++ b/src/methods/orderbookMethods.ts
@@ -12,7 +12,7 @@ import { normalizePrice, normalizeVolume } from "../lib/conversion";
 import { EncodedData, Encodings } from "../lib/encodedData";
 import { ErrFailedBalanceCheck, ErrInsufficientBalance, ErrUnsupportedFilterStatus } from "../lib/errors";
 import { MarketPairs } from "../lib/market";
-import { MarketDetails, NullConsole, Order, OrderbookFilter, OrderID, OrderInputs, OrderInputsAll, OrderSettlement, OrderSide, OrderStatus, OrderType, Token, TraderOrder, Transaction } from "../types";
+import { MarketDetails, NullConsole, Order, OrderbookFilter, OrderID, OrderInputs, OrderInputsAll, OrderSettlement, OrderSide, OrderStatus, OrderType, SimpleConsole, Token, TraderOrder, Transaction, TransactionOptions } from "../types";
 import { atomicBalances } from "./atomicMethods";
 import { onTxHash } from "./balanceActionMethods";
 import { balances, getTokenDetails } from "./balancesMethods";
@@ -73,7 +73,7 @@ const isValidDecimals = (order: OrderInputsAll, decimals: number): boolean => {
 export const openOrder = async (
     sdk: RenExSDK,
     orderInputsIn: OrderInputs,
-    simpleConsole = NullConsole,
+    options?: TransactionOptions,
 ): Promise<{ traderOrder: TraderOrder, promiEvent: PromiEvent<Transaction> | null }> => {
     const marketDetail = MarketPairs.get(orderInputsIn.symbol);
     if (!marketDetail) {
@@ -119,6 +119,9 @@ export const openOrder = async (
 
     const retrievedBalances = await balances(sdk, [spendToken, feeToken]);
     let balance = new BigNumber(0);
+
+    const { simpleConsole, awaitConfirmation, gasPrice } = await defaultTransactionOptions(sdk, options);
+
     simpleConsole.log("Verifying trader balance");
     if (orderSettlement === OrderSettlement.RenEx) {
         const spendTokenBalance = retrievedBalances.get(spendToken);
@@ -231,7 +234,6 @@ export const openOrder = async (
 
     // Submit order and the signature to the orderbook
     simpleConsole.log("Waiting for transaction signature");
-    const gasPrice = await getGasPrice(sdk);
     let txHash: string;
     let promiEvent;
     try {
@@ -242,6 +244,11 @@ export const openOrder = async (
     }
 
     simpleConsole.log("Order submitted.");
+
+    if (awaitConfirmation) {
+        await promiEvent;
+        simpleConsole.log("Order confirmed.");
+    }
 
     const traderOrder = {
         orderInputs,
@@ -270,12 +277,17 @@ export const openOrder = async (
 export const cancelOrder = async (
     sdk: RenExSDK,
     orderID: OrderID,
+    options?: TransactionOptions,
 ): Promise<{ promiEvent: PromiEvent<Transaction> | null }> => {
     const orderIDHex = new EncodedData(orderID, Encodings.BASE64).toHex();
+    const { awaitConfirmation, gasPrice } = await defaultTransactionOptions(sdk, options);
 
-    const gasPrice = await getGasPrice(sdk);
+    const promiEvent = sdk._contracts.orderbook.cancelOrder(orderIDHex, { from: sdk.getAddress(), gasPrice });
+    if (awaitConfirmation) {
+        await promiEvent;
+    }
     return {
-        promiEvent: sdk._contracts.orderbook.cancelOrder(orderIDHex, { from: sdk.getAddress(), gasPrice })
+        promiEvent
     };
 };
 
@@ -329,4 +341,24 @@ export const updateAllOrderStatuses = async (sdk: RenExSDK, orders?: TraderOrder
 export const getOrderBlockNumber = async (sdk: RenExSDK, orderID: string): Promise<number> => {
     const orderIDHex = new EncodedData(orderID, Encodings.BASE64).toHex();
     return new BN(await sdk._contracts.orderbook.orderBlockNumber(orderIDHex)).toNumber();
+};
+
+export const defaultTransactionOptions = async (sdk: RenExSDK, options?: TransactionOptions): Promise<{
+    awaitConfirmation: boolean;
+    gasPrice: number | undefined;
+    simpleConsole: SimpleConsole;
+}> => {
+    let awaitConfirmation = true;
+    let gasPrice;
+    let simpleConsole = NullConsole;
+    if (options) {
+        awaitConfirmation = options.awaitConfirmation || awaitConfirmation;
+        gasPrice = options.gasPrice || await getGasPrice(sdk);
+        simpleConsole = options.simpleConsole || simpleConsole;
+    }
+    return {
+        awaitConfirmation,
+        gasPrice,
+        simpleConsole,
+    };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,10 @@ export interface TransactionOptions {
     simpleConsole?: SimpleConsole;
 }
 
+export interface WithdrawTransactionOptions extends TransactionOptions {
+    withoutIngressSignature?: boolean;
+}
+
 // If BalanceAction is changed, then it's serialize / deserialize functions
 // should be updated as well.
 export interface BalanceAction {

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,12 @@ export enum TransactionStatus {
     Replaced = "replaced",
 }
 
+export interface TransactionOptions {
+    awaitConfirmation?: boolean;
+    gasPrice?: number | undefined;
+    simpleConsole?: SimpleConsole;
+}
+
 // If BalanceAction is changed, then it's serialize / deserialize functions
 // should be updated as well.
 export interface BalanceAction {


### PR DESCRIPTION
### Description
This PR will add a warning message when users setup the SDK to use a network different to network of the provider.

Additionally, this PR also updates the links to the cloneable examples, adds additional transaction options when opening and cancelling orders, awaits for transaction confirmation by default, and fixes a bug where the `orderID` returned from `fetchOrderbook()` is returned as Hex instead of Base64.

### Motivation
We cannot trust users to read the documentation which explains how to setup the SDK correctly.

### Design
We want the call to constructor to return immediately. Although the call to check the provider network is asynchronous but we don't wait for it and instead just log the potential warning whenever the Promise resolves.