### PR TITLE
Fixed WBTC wrapping statuses

### DIFF
--- a/src/lib/swapper.ts
+++ b/src/lib/swapper.ts
@@ -177,8 +177,12 @@ export async function findMatchingSwapReceipt(check: (swap: SwapReceipt) => bool
 
     for (const innerSwap of response.swaps) {
         const swap: SwapReceipt = fixSwapType(innerSwap);
-        if (check(swap)) {
-            return swap;
+        try {
+            if (check(swap)) {
+                return swap;
+            }
+        } catch {
+            // Ignore error
         }
     }
     throw new Error(errors.UnableToFindMatchingSwap);

--- a/src/methods/atomicMethods.ts
+++ b/src/methods/atomicMethods.ts
@@ -180,11 +180,15 @@ export async function fetchAtomicOrderStatus(sdk: RenExSDK, orderID: EncodedData
 export async function fetchAtomicOrder(sdk: RenExSDK, orderID: EncodedData): Promise<SwapReceipt> {
     try {
         const swap = await findMatchingSwapReceipt((swapReceipt) => {
-            try {
-                return swapReceipt.delay !== undefined && swapReceipt.delayInfo.message.orderID === orderID.toBase64();
-            } catch (error) {
-                return false;
+            if (swapReceipt.id === orderID.toBase64()) {
+                return true;
+            } else if (
+                swapReceipt.delayInfo && swapReceipt.delayInfo.message &&
+                swapReceipt.delayInfo.message.orderID === orderID.toBase64()
+            ) {
+                return true;
             }
+            return false;
         }, sdk._networkData.network);
         return swap;
     } catch (error) {


### PR DESCRIPTION
Previously, statuses for wrap requests were always returned as `NOT_SUBMITTED` since they had no delay info.